### PR TITLE
Minor markup fix.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 
 Note this project is for team members of the Penn State Software Enginnering 500, Summer 2016, Team 5 group. If you are not one of those team members, any pull requests, bug reports, etc will be rejected until the end of August, 2016. 
 
-#Repositories
+# Repositories
 
 There are going to be several levels of source control in use. 
 


### PR DESCRIPTION
Without the space after the octothorpe, the heading doesn't render as a heading in some markdown viewers (e.g., the one on cloud9).
