### PR TITLE
Added ability to run tests from the command line.

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -20,3 +20,4 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
 practicalmeteor:mocha
+dispatch:mocha-phantomjs

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -20,6 +20,9 @@ ddp-common@1.2.5
 ddp-server@1.2.6
 deps@1.0.12
 diff-sequence@1.0.5
+dispatch:mocha-core@0.0.2
+dispatch:mocha-phantomjs@0.1.5
+dispatch:phantomjs-tests@0.0.5
 ecmascript@0.4.3
 ecmascript-runtime@0.2.10
 ejson@1.0.11

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+machine:
+  node:
+    version: 0.10.43
+dependencies:
+  override:
+    -curl https://install.meteor.com | /bin/sh
+    -npm install
+test:
+  override:
+    - meteor test --once --driver-package dispatch:mocha-phantomjs

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,8 @@ machine:
     version: 0.10.43
 dependencies:
   override:
-    -curl https://install.meteor.com | /bin/sh
-    -npm install
+    - curl https://install.meteor.com | /bin/sh
+    - npm install
 test:
   override:
     - meteor test --once --driver-package dispatch:mocha-phantomjs


### PR DESCRIPTION
Using the dispatch:mocha-phantomjs project to give command line test output.
To get it, run `meteor test --once --driver-package dispatch:mocha-phantomjs
