### PR TITLE
Changed command line testing to practicalmeteor:

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -19,5 +19,5 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
+practicalmeteor:mocha-console-runner
 practicalmeteor:mocha
-dispatch:mocha-phantomjs

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -20,9 +20,6 @@ ddp-common@1.2.5
 ddp-server@1.2.6
 deps@1.0.12
 diff-sequence@1.0.5
-dispatch:mocha-core@0.0.2
-dispatch:mocha-phantomjs@0.1.5
-dispatch:phantomjs-tests@0.0.5
 ecmascript@0.4.3
 ecmascript-runtime@0.2.10
 ejson@1.0.11
@@ -56,6 +53,7 @@ ordered-dict@1.0.7
 practicalmeteor:chai@2.1.0_1
 practicalmeteor:loglevel@1.2.0_2
 practicalmeteor:mocha@2.4.5_2
+practicalmeteor:mocha-console-runner@0.2.0
 practicalmeteor:mocha-core@0.1.4
 practicalmeteor:sinon@1.14.1_2
 promise@0.6.7

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,9 @@ machine:
     version: 0.10.43
 dependencies:
   override:
+    - npm install -g spacejam
     - curl https://install.meteor.com | /bin/sh
     - npm install
 test:
   override:
-    - meteor test --once --driver-package dispatch:mocha-phantomjs
+    - meteor npm run test-cli-once

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "start": "meteor run",
     "test": "meteor test --driver-package practicalmeteor:mocha --port 8082",
-    "test-cli": "meteor test --driver-package dispatch:mocha-phantomjs",
-    "test-cli-once": "meteor test --driver-package dispatch:mocha-phantomjs --once"
+    "test-cli": "spacejam test --driver-package practicalmeteor:mocha-console-runner",
+    "test-cli-once": "spacejam test --driver-package practicalmeteor:mocha-console-runner --once"
   },
   "dependencies": {
     "meteor-node-stubs": "~0.2.0"


### PR DESCRIPTION
Because of the bug that caused an incompatibility between the
practicalmeteor:mocha web-ui tests and the dispatch:phantom-js cli tests,
we've moved the cli tests to use spacejam with practicalmeteor.

Fixes #86
