### PR TITLE
Fix for the windows crash bug

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -56,9 +56,9 @@ observe-sequence@1.0.12
 ordered-dict@1.0.8
 practicalmeteor:chai@2.1.0_1
 practicalmeteor:loglevel@1.2.0_2
-practicalmeteor:mocha@2.4.5_4
-practicalmeteor:mocha-console-runner@0.2.2
-practicalmeteor:mocha-core@1.0.0
+practicalmeteor:mocha@2.4.5_5
+practicalmeteor:mocha-console-runner@0.2.3
+practicalmeteor:mocha-core@1.0.1
 practicalmeteor:sinon@1.14.1_2
 promise@0.7.2_1
 random@1.0.10


### PR DESCRIPTION
This just updated the version of practicalmeteor:mocha and seems to have fixed it.
