### PR TITLE
Updated dispatch:mocha-phantomjs to fix firefox bug.

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -20,7 +20,7 @@ ddp-common@1.2.6
 ddp-server@1.2.8_1
 deps@1.0.12
 diff-sequence@1.0.6
-dispatch:mocha-phantomjs@0.1.6
+dispatch:mocha-phantomjs@0.1.7
 dispatch:phantomjs-tests@0.0.5
 ecmascript@0.4.6_1
 ecmascript-runtime@0.2.11_1


### PR DESCRIPTION
Moving to version 0.1.7 of dispatch:mocha-phantomjs which fixes the
practicalmeteor:mocha display when rendering in firefox.
