### PR TITLE
Setup only allows clicking on valid destination

### DIFF
--- a/imports/api/ship.js
+++ b/imports/api/ship.js
@@ -37,7 +37,7 @@ export function overlap(ship, row, col, vertical, ships) {
   return false;
 }
 
-export function checkOverlap(ship_type, row, col, vertical, positions) {
+export function checkPlacement(ship_type, row, col, vertical, positions) {
   if(positions[ship_type]) {
     // This is moving a ship, we don't want to include the pre-move ship in the
     // overlap test. This makes a copy that we can remove it from.
@@ -45,12 +45,25 @@ export function checkOverlap(ship_type, row, col, vertical, positions) {
     delete positions[ship_type];
   }
   if(overlap(ship_type, row, col, vertical, positions)) {
-    throw 'Ships Overlapping';
+    return 'Ships overlapping';
   }
+  const len = lengths[ship_type];
+  if(
+    row < 0 || col < 0 ||
+    row > 9 || col > 9 ||
+    (vertical && row + len - 1 > 9) ||
+    (!vertical && col + len - 1 > 9)
+  ) {
+    return 'Ship off of board';
+  }
+  return false;
 }
 
 export function place(ship_type, row, col, vertical, positions) {
-  checkOverlap(ship_type, row, col, vertical, positions);
+  const check = checkPlacement(ship_type, row, col, vertical, positions);
+  if(check) {
+    throw check;
+  }
 
   if(!positions[ship_type]) {
     positions[ship_type] = {};

--- a/imports/api/ship.test.js
+++ b/imports/api/ship.test.js
@@ -133,7 +133,7 @@ describe('api/ships.js', function() {
 
       assert.throw(function() {
         Ship.place("battleship", 0, 0, true, positions);
-      }, "Ships Overlapping");
+      }, "Ships overlapping");
 
       assert.equal(0, positions.carrier.col); // Still there
     });

--- a/imports/ui/board.js
+++ b/imports/ui/board.js
@@ -1,6 +1,7 @@
 /** Configuration for JSHint to recognize automatic globals: */
 
 import * as Game from '/imports/api/game.js';
+import * as Ship from '/imports/api/ship.js';
 import * as Square from '/imports/api/square.js';
 
 import './board.html';
@@ -31,8 +32,15 @@ Template.board_cell.helpers({
       }
     }
     if(Game.userCanSetup(game, user) && own) {
-      if(Session.get('ship')) {
-        list += " clickable";
+      const type = Session.get('ship');
+      const player = Game.getUserPlayer(game, Meteor.user());
+      if(type) {
+        const ships = game[player].ships;
+        let vertical = ships[type].vertical;
+        if(Session.get('rotate')) vertical = !vertical;
+        if(!Ship.checkPlacement(type, row, col, vertical, ships)) {
+          list += " clickable";
+        }
       } else if(square.state === "S") {
         list += " clickable";
       }


### PR DESCRIPTION
Updated board to only make cells clickable during setup placement if they are
valid destinations.

Fixes #202
